### PR TITLE
Set cookies for paths that do not match the response URI

### DIFF
--- a/lib/rack/test/cookie_jar.rb
+++ b/lib/rack/test/cookie_jar.rb
@@ -12,7 +12,7 @@ module Rack
 
       # The name of the cookie, will be a string
       attr_reader :name
-      
+
       # The value of the cookie, will be a string or nil if there is no value.
       attr_reader :value
 
@@ -86,8 +86,8 @@ module Rack
         expires && expires < Time.now
       end
 
-      # Whether the cookie is valid for the given URI.
-      def valid?(uri)
+      # Whether the cookie is valid to set or send for the given URI.
+      def valid?(uri, context = :sending)
         uri ||= default_uri
 
         uri.host = @default_host if uri.host.nil?
@@ -95,7 +95,7 @@ module Rack
         real_domain = domain =~ /^\./ ? domain[1..-1] : domain
         !!((!secure? || (secure? && uri.scheme == 'https')) &&
           uri.host =~ Regexp.new("#{'^' if @exact_domain_match}#{Regexp.escape(real_domain)}$", Regexp::IGNORECASE) &&
-          uri.path =~ Regexp.new("^#{Regexp.escape(path)}"))
+          (context == :sending ? uri.path =~ Regexp.new("^#{Regexp.escape(path)}") : true))
       end
 
       # Cookies that do not match the URI will not be sent in requests to the URI.
@@ -190,7 +190,7 @@ module Rack
 
         raw_cookies.each do |raw_cookie|
           cookie = Cookie.new(raw_cookie, uri, @default_host)
-          self << cookie if cookie.valid?(uri)
+          self << cookie if cookie.valid?(uri, :setting)
         end
       end
 

--- a/spec/fixtures/fake_app.rb
+++ b/spec/fixtures/fake_app.rb
@@ -60,6 +60,10 @@ module Rack
           end
         end
 
+        if path == '/redirect-after-cookie-set-for-different-path' && method == 'GET'
+          return [302, { 'set-cookie' => "value=1; path=/cookies;", 'location' => '/cookies/show' }, []]
+        end
+
         if path == '/redirected'
           additional_info = if method == 'GET'
             ", session #{session.inspect} with options #{env['rack.session.options'].inspect}"
@@ -114,7 +118,7 @@ module Rack
 
         if path == '/cookies/set-multiple' && method == 'GET'
           value = Rack.release >= '2.3' ? ["key1=value1", "key2=value2"] : "key1=value1\nkey2=value2"
-          
+
           return [200, { 'set-cookie' => value }, ['Set']]
         end
 

--- a/spec/rack/test/cookie_spec.rb
+++ b/spec/rack/test/cookie_spec.rb
@@ -258,4 +258,10 @@ describe "Rack::Test::Session" do
     request '/cookies/show', cookie: 'value=1'
     last_request.cookies.must_equal 'value' => '1'
   end
+
+  it 'sets and subsequently sends cookies when redirecting to the path of the cookie' do
+    get '/redirect-after-cookie-set-for-different-path'
+    follow_redirect!
+    last_request.cookies.must_equal 'value' => '1'
+  end
 end


### PR DESCRIPTION
As a Chrome user
When I visit `/foo` that sets a cookie for path `/bar` and redirects me to `/bar`
Then the cookie is sent with the request to `/bar`

`Rack::Test` does not currently reflect this behaviour.

When a cookie is set with the `merge` method, the `valid?` check is performed.
The same `valid?` check is performed when deciding which cookies to send with a request.

It is my understanding that the _validity_ of a cookie is not the same in the context of _setting_ as it is when _sending_.

This PR is an attempt to both demonstrate the problem I am facing, and begin a discussion around the appetite for solving such problem, and the best way of doing so.